### PR TITLE
Plain snippet for simple Ruby class

### DIFF
--- a/snippets/ruby_files.cson
+++ b/snippets/ruby_files.cson
@@ -20,8 +20,8 @@
   'class':
     'prefix': 'class'
     'body': """
-      class ${1:ClassName} ${3:< ${2:ActiveRecord::Base}}
-        ${4:#code}
+      class ${1:ClassName}
+        ${2:#code}
       end
     """
 


### PR DESCRIPTION
We're already have `model` snippet with almost same behavior. 
Why not to create simple class objects instead for `class` prefix? 
What do you think?