### PR TITLE
[update] list of ERB block tags. Strip whitespace

### DIFF
--- a/lib/rails-snippets.coffee
+++ b/lib/rails-snippets.coffee
@@ -3,7 +3,7 @@
 {CompositeDisposable} = require 'atom'
 
 # erb supported blocks
-ERB_BLOCKS = [['<%=', '%>'], ['<%', '%>'], ['<%#', '%>']]
+ERB_BLOCKS = [['<%=', '%>'], ['<%', '%>'], ['<%-', '-%>'], ['<%=', '-%>'], ['<%#', '%>'], ['<%', '-%>']]
 ERB_REGEX = '<%(=?|-?|#?)\s{2}(-?)%>'
 # matches the opening bracket
 ERB_OPENER_REGEX = '<%[\\=\\#]?'


### PR DESCRIPTION
I'm a recent migrant from Sublime Text and love your package.

However, I'm proposing adding a few more ERB block types, specifically ones that support stripping whitespace. 

Via [ActionView::Base Documentation](http://api.rubyonrails.org/classes/ActionView/Base.html): 
"When on a line that only contains whitespaces except for the tag, <% %> suppress leading and trailing whitespace, including the trailing newline. <% %> and <%- -%> are the same. Note however that <%= %> and <%= -%> are different: only the latter removes trailing whitespaces."