### PR TITLE
Adds "ctrl->" keybinding to attend non mac users

### DIFF
--- a/keymaps/rails-snippets.cson
+++ b/keymaps/rails-snippets.cson
@@ -1,2 +1,3 @@
 'atom-text-editor:not(.mini)':
   'cmd->': 'rails-snippets:toggleErb'
+  'ctrl->': 'rails-snippets:toggleErb'


### PR DESCRIPTION
With one finger you can press ctrl+shift and with other hand the . key.
It's a lot of easy than super+shift+. on normal pc keyboards.