### PR TITLE
Removing "should" from RSpec descriptions

### DIFF
--- a/snippets/ruby_files.cson
+++ b/snippets/ruby_files.cson
@@ -4,7 +4,7 @@
   'it':
     'prefix': 'it'
     'body': """
-      it "should $1" do
+      it "$1" do
         $2
       end
     """


### PR DESCRIPTION
As per http://betterspecs.org/#should specs should look like:

`it 'does not change timings' do`

Rather than the older convention of:

`it 'should not change timings' do`