### PR TITLE
Split tests and assertions

### DIFF
--- a/snippets/assertions.cson
+++ b/snippets/assertions.cson
@@ -60,3 +60,6 @@
     'prefix': 'asr'
     'body': 'assert_redirected_to ${1:users}_path$0'
 
+  'assert_selector':
+    'prefix': 'asl'
+    'body': 'assert_selector "${1:h1}", text: "${2:Hello}"'

--- a/snippets/assertions.cson
+++ b/snippets/assertions.cson
@@ -1,36 +1,4 @@
 '.source.ruby, .source.ruby.rails':
-  'it':
-    'prefix': 'it'
-    'body': """
-      it "$1" do
-        $2
-      end
-    """
-
-  'describe':
-    'prefix': 'describe'
-    'body': """
-      describe "when $1" do
-        $2
-      end
-    """
-
-  'context':
-    'prefix': 'context'
-    'body': """
-      context "when $1" do
-        $2
-      end
-    """
-
-  'test case':
-    'prefix': 'test'
-    'body': """
-      test "when ${1:method_or_case}" do
-        ${2:assert true}
-      end
-    """
-
   'assert':
     'prefix': 'ast'
     'body': 'assert ${1:true}${2:, "${3:expected ${1:true} to be true}"}'
@@ -91,3 +59,4 @@
   'assert_redirected_to':
     'prefix': 'asr'
     'body': 'assert_redirected_to ${1:users}_path$0'
+

--- a/snippets/tests_and_specs.cson
+++ b/snippets/tests_and_specs.cson
@@ -31,3 +31,18 @@
       end
     """
 
+  'setup':
+    'prefix': 'set'
+    'body': """
+      setup do
+        ${1}
+      end
+    """
+
+  'teardown':
+    'prefix': 'tear'
+    'body': """
+      teardown do
+        ${1}
+      end
+    """

--- a/snippets/tests_and_specs.cson
+++ b/snippets/tests_and_specs.cson
@@ -1,0 +1,33 @@
+'.source.ruby, .source.ruby.rails':
+  'it':
+    'prefix': 'it'
+    'body': """
+      it "$1" do
+        $2
+      end
+    """
+
+  'describe':
+    'prefix': 'describe'
+    'body': """
+      describe "when $1" do
+        $2
+      end
+    """
+
+  'context':
+    'prefix': 'context'
+    'body': """
+      context "when $1" do
+        $2
+      end
+    """
+
+  'test case':
+    'prefix': 'test'
+    'body': """
+      test "when ${1:method_or_case}" do
+        ${2:assert true}
+      end
+    """
+


### PR DESCRIPTION
Hi. Just thinking that the `tests_and_assertions.cson` can be splited. So in a only `assertions.cson` write everything about asserts and another file `tests_and_specs.cson` for test cases related snippets

Cheers